### PR TITLE
ïnsert repositories and saving on localStorage

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -19,7 +19,19 @@ interface Repository {
 const Dashboard: React.FC = () => {
   const [newRepo, setNewRepo] = useState('');
   const [inputError, setInputError] = useState('');
-  const [repositories, setRepositories] = useState<Repository[]>([]);
+  const [repositories, setRepositories] = useState<Repository[]>(() => {
+   const storagedRepositories = localStorage.getItem('@GithubExplorer:repositories');
+
+   if(storagedRepositories) {
+     return JSON.parse(storagedRepositories);
+   }
+
+   return [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('@GithubExplorer:repositories', JSON.stringify(repositories));
+  }, [repositories]);
 
   async function handleAddRepository(event: FormEvent<HTMLFormElement>): Promise<void> {
     event.preventDefault();


### PR DESCRIPTION
Neste branch foi realizado a inserção de repositórios para salvar no banco de dados do navegador conhecido por todos como Local Storage, utilizei UseEffect para salvar sempre que há mudança no repositório e outro método importante a inicialização do estado repositories que pode receber uma função.